### PR TITLE
feat: Add storage index and cleanup assignments on de-register

### DIFF
--- a/pallets/acurast/src/tests.rs
+++ b/pallets/acurast/src/tests.rs
@@ -291,7 +291,7 @@ fn test_assign_job() {
 
         assert_eq!(
             Some(vec![(alice_account_id(), registration.script.clone())]),
-            Acurast::stored_job_assignment(processor_account_id())
+            Acurast::processor_assigned_jobs(processor_account_id())
         );
 
         assert_eq!(


### PR DESCRIPTION
This merge request updates the storage with a map that indexes the assigned processors for each job. This allows the assignments to be clean for a given JOB when `deregister` is called.

The current implementation could be improved by replacing the `Vec` with a `HashSet` or `Map<JobId<T::AccountId>, ()>`. But this seems to be trick: https://substrate-developer-hub.github.io/docs/en/knowledgebase/advanced/no-hash-collections

Missing tasks:
- [ ] Update benchmarks and weights