### PR TITLE
fix(acurast-common): Ignore attestation code when 'attestation' feature is not enabled

### DIFF
--- a/pallets/acurast/common/src/lib.rs
+++ b/pallets/acurast/common/src/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "attestation")]
 mod attestation;
-mod types;
-
+#[cfg(feature = "attestation")]
 pub use attestation::*;
+
+mod types;
 pub use types::*;


### PR DESCRIPTION
This MR fixes pallet `pallet-acurast-fulfillment-receiver`.

**Context:**
[aattestation.rs](https://github.com/Acurast/acurast-core/blob/develop/pallets/acurast/common/src/attestation.rs) code was being compiled even when the `attestation` feature was disabled.
