### PR TITLE
Schedule checks (respecting max_start_delay)

### DIFF
--- a/pallets/acurast/common/src/lib.rs
+++ b/pallets/acurast/common/src/lib.rs
@@ -4,6 +4,8 @@
 mod attestation;
 #[cfg(feature = "attestation")]
 pub use attestation::*;
+#[cfg(test)]
+mod tests;
 
 mod types;
 pub use types::*;

--- a/pallets/acurast/common/src/tests.rs
+++ b/pallets/acurast/common/src/tests.rs
@@ -1,0 +1,267 @@
+#![cfg(test)]
+
+use crate::Schedule;
+macro_rules! tests {
+    ($property_test_func:ident {
+        $( $(#[$attr:meta])* $test_name:ident( $( $param:expr ),* ); )+
+    }) => {
+        $(
+            $(#[$attr])*
+            #[test]
+            fn $test_name() {
+                $property_test_func($( $param ),* )
+            }
+        )+
+    }
+}
+
+fn test_schedule_execution_count(schedule: Schedule, exp_count: u64) {
+    assert_eq!(schedule.execution_count(), exp_count);
+}
+
+tests! {
+    test_schedule_execution_count {
+        // ╭start ╭end
+        // ■■■■■■■■
+        test_schedule_execution_count_tight(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 8,
+                interval: 2,
+                max_start_delay: 0,
+            },
+            4
+        );
+        // ╭start         ╭end
+        // ■■___■■___■■___
+        test_schedule_execution_count_fit(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 15,
+                interval: 5,
+                max_start_delay: 0,
+            },
+            3
+        );
+        // ╭start   ╭end
+        // ■■___■■__
+        test_schedule_execution_count_last_not_fitting(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 9,
+                interval: 5,
+                max_start_delay: 0,
+            },
+            2
+        );
+        // ╭start         ╭end
+        // ■■□□_■■□□_■■□□_
+        // □■■□_□■■□_□■■□_
+        // □□■■_□□■■_□□■■_
+        test_schedule_execution_count_delay_fit(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 15,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            3
+        );
+        // ╭start   ╭end
+        // ■■□□_■■□□
+        // □■■□_□■■□
+        // □□■■_□□■■
+        test_schedule_execution_count_delay_last_not_fitting(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 9,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            2
+        );
+        // ╭start     ╭end
+        // ■■□□_■■□□_■■□□
+        // □■■□_□■■□_□■■□
+        // □□■■_□□■■_□□■■
+        test_schedule_execution_count_delay_reaching_over_end(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 11,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            3
+        );
+        // ╭start=end
+        //
+        test_schedule_execution_count_zero_fits(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 0,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            0
+        );
+        // ╭start=end-1
+        // ■■□□
+        // □■■□
+        // □□■■
+        test_schedule_execution_count_one_fit(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 1,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            1
+        );
+        //    ╭start     ╭end
+        // ___■■□□_■■□□_■■□□
+        // ___□■■□_□■■□_□■■□
+        // ___□□■■_□□■■_□□■■
+        test_schedule_execution_count_start_time_indifferent(
+            Schedule{
+                duration: 2,
+                start_time: 3,
+                end_time: 14,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            3
+        );
+    }
+}
+
+fn test_schedule_iter(schedule: Schedule, start_delay: u64, exp_starts: Vec<u64>) {
+    assert_eq!(
+        schedule.iter(start_delay).unwrap().collect::<Vec<u64>>(),
+        exp_starts
+    );
+}
+
+tests! {
+    test_schedule_iter {
+        // ╭start  ╭end
+        // ■■■■■■■■
+        test_schedule_iter_tight(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 8,
+                interval: 2,
+                max_start_delay: 0,
+            },
+            0,
+            vec![0,2,4,6]
+        );
+        // ╭start         ╭end
+        // ■■___■■___■■___
+        test_schedule_iter_fit(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 15,
+                interval: 5,
+                max_start_delay: 0,
+            },
+            0,
+            vec![0,5,10]
+        );
+        // ╭start   ╭end
+        // ■■___■■__
+        test_schedule_iter_last_not_fitting(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 9,
+                interval: 5,
+                max_start_delay: 0,
+            },
+            0,
+            vec![0,5]
+        );
+        // ╭start         ╭end
+        // ■■□□_■■□□_■■□□_
+        // □■■□_□■■□_□■■□_
+        // □□■■_□□■■_□□■■_
+        test_schedule_iter_delay_fit(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 15,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            0,
+            vec![0,5,10]
+        );
+        // ╭start   ╭end
+        // ■■□□_■■□□
+        // □■■□_□■■□
+        // □□■■_□□■■
+        test_schedule_iter_delay_last_not_fitting(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 9,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            0,
+            vec![0,5]
+        );
+        // ╭start     ╭end
+        // ■■□□_■■□□_■■□□
+        // □■■□_□■■□_□■■□
+        // □□■■_□□■■_□□■■
+        test_schedule_iter_delay_reaching_over_end(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 11,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            0,
+            vec![0,5,10]
+        );
+        // ╭start=end
+        //
+        test_schedule_iter_zero_fits(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 0,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            0,
+            vec![]
+        );
+        // ╭start=end-1
+        // ■■□□
+        // □■■□
+        // □□■■
+        test_schedule_iter_one_fit(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 1,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            0,
+            vec![0]
+        );
+    }
+}

--- a/pallets/acurast/common/src/tests.rs
+++ b/pallets/acurast/common/src/tests.rs
@@ -280,9 +280,8 @@ tests! {
 
 fn test_schedule_overlaps(schedule: Schedule, start_delay: u64, ranges: Vec<((u64, u64), bool)>) {
     for (range, exp) in ranges.iter() {
-        let normalized_schedule = &schedule.normalize(start_delay).unwrap();
         assert_eq!(
-            &normalized_schedule.overlaps(range.0, range.1).unwrap(),
+            &schedule.overlaps(start_delay, range.0, range.1).unwrap(),
             exp,
             "{:?}.overlaps(start_delay: {}, range, ({}, {})) != {}",
             schedule,

--- a/pallets/acurast/common/src/tests.rs
+++ b/pallets/acurast/common/src/tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use crate::Schedule;
+
 macro_rules! tests {
     ($property_test_func:ident {
         $( $(#[$attr:meta])* $test_name:ident( $( $param:expr ),* ); )+
@@ -192,8 +193,6 @@ tests! {
         );
         // ╭start         ╭end
         // ■■□□_■■□□_■■□□_
-        // □■■□_□■■□_□■■□_
-        // □□■■_□□■■_□□■■_
         test_schedule_iter_delay_fit(
             Schedule{
                 duration: 2,
@@ -204,6 +203,19 @@ tests! {
             },
             0,
             vec![0,5,10]
+        );
+        // ╭start         ╭end
+        // □□■■_□□■■_□□■■_
+        test_schedule_iter_delay_fit_2(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 15,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            2,
+            vec![2,7,12]
         );
         // ╭start   ╭end
         // ■■□□_■■□□
@@ -262,6 +274,77 @@ tests! {
             },
             0,
             vec![0]
+        );
+    }
+}
+
+fn test_schedule_overlaps(schedule: Schedule, start_delay: u64, ranges: Vec<((u64, u64), bool)>) {
+    for (range, exp) in ranges.iter() {
+        assert_eq!(
+            &schedule.overlaps(start_delay, range).unwrap(),
+            exp,
+            "{:?}.overlaps(start_delay: {}, range, ({}, {})) != {}",
+            schedule,
+            start_delay,
+            range.0,
+            range.1,
+            exp
+        );
+    }
+}
+
+tests! {
+    test_schedule_overlaps {
+        // ╭start ╭end
+        // ■■■■■■■■
+        // ranges:
+        // ■
+        //         ■■
+        test_schedule_overlaps_tight(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 8,
+                interval: 2,
+                max_start_delay: 0,
+            },
+            0,
+            vec![((0,1), true), ((8,10), false)]
+        );
+        // ╭start         ╭end
+        // ■■___■■___■■___
+        //      ■■
+        //       ■■
+        //        ■■
+        //             ■■■■
+        test_schedule_overlaps_fit(
+            Schedule{
+                duration: 2,
+                start_time: 0,
+                end_time: 15,
+                interval: 5,
+                max_start_delay: 0,
+            },
+            0,
+            vec![((5,6), true), ((6,7), true), ((7,8), false), ((12, 16), false)]
+        );
+        //    ╭start     ╭end
+        // ___□□■■_□□■■_□□■■
+        // ranges:
+        // ■■■
+        //   ■■
+        //           ■■
+        //             ■■■
+        test_schedule_overlaps_start_time(
+            Schedule{
+                duration: 2,
+                start_time: 3,
+                end_time: 14,
+                interval: 5,
+                max_start_delay: 2,
+            },
+            2,
+            vec![((0,3), false), ((2,4), false), ((10,12), true), ((12,15), false)]
         );
     }
 }

--- a/pallets/acurast/common/src/tests.rs
+++ b/pallets/acurast/common/src/tests.rs
@@ -280,8 +280,9 @@ tests! {
 
 fn test_schedule_overlaps(schedule: Schedule, start_delay: u64, ranges: Vec<((u64, u64), bool)>) {
     for (range, exp) in ranges.iter() {
+        let normalized_schedule = &schedule.normalize(start_delay).unwrap();
         assert_eq!(
-            &schedule.overlaps(start_delay, range).unwrap(),
+            &normalized_schedule.overlaps(range.0, range.1).unwrap(),
             exp,
             "{:?}.overlaps(start_delay: {}, range, ({}, {})) != {}",
             schedule,

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -377,6 +377,7 @@ pub mod pallet {
         pub fn report(
             origin: OriginFor<T>, // source
             job_id: JobId<T::AccountId>,
+            last: bool,
         ) -> DispatchResultWithPostInfo {
             let who = ensure_signed(origin)?;
 
@@ -426,24 +427,7 @@ pub mod pallet {
                 Error::<T>::ReportOutsideSchedule
             );
 
-            // TODO we can't actually be sure that now is not outdated and only therefore we miss that this is indeed
-            // the last execution of the schedule -> should we add a cooprative flag to report, indicating that this is the last?
-            // Alternatively we could check assignment.sla.met == assignment.sla.total, but that would fail if some reports got missing (due to network errors).
-            // Best solution: add a counter to report extrinsic that declares which execution it refers to.
-            //
-            // Timing check was
-            // ```
-            // let last_execution_start = registration
-            //     .schedule
-            //     .end_time
-            //     .checked_sub(normalized_schedule.0.duration)
-            //     .ok_or(Error::<T>::CalculationOverflow)?;
-            // if now
-            //     >= last_execution_start
-            //         .checked_sub(T::ReportTolerance::get())
-            //         .ok_or(Error::<T>::CalculationOverflow)?
-            // ```
-            if assignment.sla.met == assignment.sla.total {
+            if last {
                 // TODO update reputation since we don't expect further reports for this job
 
                 // removed completed job from all storage points (completed SLA gets still deposited in event below)

--- a/pallets/marketplace/src/lib.rs
+++ b/pallets/marketplace/src/lib.rs
@@ -411,18 +411,15 @@ pub mod pallet {
             let registration = <StoredJobRegistration<T>>::get(&job_id.0, &job_id.1)
                 .ok_or(pallet_acurast::Error::<T>::JobRegistrationNotFound)?;
 
-            let normalized_schedule = registration
-                .schedule
-                .normalize(assignment.start_delay)
-                .ok_or(Error::<T>::CalculationOverflow)?;
             let now = Self::now()?;
             let now_max = now
                 .checked_add(T::ReportTolerance::get())
                 .ok_or(Error::<T>::CalculationOverflow)?;
 
             ensure!(
-                normalized_schedule
-                    .overlaps(now, now_max)
+                registration
+                    .schedule
+                    .overlaps(assignment.start_delay, now, now_max)
                     .ok_or(Error::<T>::CalculationOverflow)?,
                 Error::<T>::ReportOutsideSchedule
             );

--- a/pallets/marketplace/src/mock.rs
+++ b/pallets/marketplace/src/mock.rs
@@ -132,16 +132,15 @@ parameter_types! {
 }
 parameter_types! {
     pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights::simple_max(Weight::from_ref_time(1024));
-    pub const MinimumPeriod: u64 = 6000;
+    pub const MinimumPeriod: u64 = 2000;
     pub AllowedRevocationListUpdate: Vec<AccountId> = vec![alice_account_id(), <Test as crate::Config>::PalletId::get().into_account_truncating()];
     pub const ExistentialDeposit: AssetAmount = EXISTENTIAL_DEPOSIT;
 }
 parameter_types! {
     pub const MaxReserves: u32 = 50;
     pub const MaxLocks: u32 = 50;
-}
-parameter_types! {
     pub const AcurastPalletId: PalletId = PalletId(*b"acrstpid");
+    pub const ReportTolerance: u64 = 12000;
 }
 
 impl frame_system::Config for Test {
@@ -287,6 +286,7 @@ impl Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type RegistrationExtra = JobRequirementsFor<Self>;
     type PalletId = AcurastPalletId;
+    type ReportTolerance = ReportTolerance;
     type AssetId = AssetId;
     type AssetAmount = AssetAmount;
     type RewardManager = MockRewardManager;

--- a/pallets/marketplace/src/tests.rs
+++ b/pallets/marketplace/src/tests.rs
@@ -6,8 +6,8 @@ use pallet_acurast::JobRegistrationFor;
 use pallet_acurast::Schedule;
 
 use crate::stub::*;
-use crate::JobRequirements;
 use crate::{mock::*, AdvertisementRestriction, Assignment, Error, JobStatus, Match, SLA};
+use crate::{JobRequirements, PlannedExecution};
 
 #[test]
 fn test_match() {
@@ -38,7 +38,10 @@ fn test_match() {
     let job_id = (alice_account_id(), registration.script.clone());
     let m = Match {
         job_id: job_id.clone(),
-        sources: vec![processor_account_id()],
+        sources: vec![PlannedExecution {
+            source: processor_account_id(),
+            start_delay: 0,
+        }],
     };
 
     ExtBuilder::default().build().execute_with(|| {
@@ -117,6 +120,7 @@ fn test_match() {
         assert_eq!(
             Some(Assignment {
                 slot: 0,
+                start_delay: 0,
                 fee_per_execution: MockAsset {
                     id: 0,
                     amount: 5_020_000
@@ -189,6 +193,7 @@ fn test_match() {
                     processor_account_id(),
                     Assignment {
                         slot: 0,
+                        start_delay: 0,
                         fee_per_execution: MockAsset {
                             id: 0,
                             amount: 5_020_000
@@ -206,6 +211,7 @@ fn test_match() {
                     processor_account_id(),
                     Assignment {
                         slot: 0,
+                        start_delay: 0,
                         fee_per_execution: MockAsset {
                             id: 0,
                             amount: 5_020_000
@@ -223,6 +229,7 @@ fn test_match() {
                     processor_account_id(),
                     Assignment {
                         slot: 0,
+                        start_delay: 0,
                         fee_per_execution: MockAsset {
                             id: 0,
                             amount: 5_020_000
@@ -317,7 +324,10 @@ fn test_no_match_schedule_overlap() {
         // the first job matches because capacity left
         let m = Match {
             job_id: job_id1.clone(),
-            sources: vec![processor_account_id()],
+            sources: vec![PlannedExecution {
+                source: processor_account_id(),
+                start_delay: 0,
+            }],
         };
         assert_ok!(AcurastMarketplace::propose_matching(
             RuntimeOrigin::signed(charlie_account_id()).into(),
@@ -327,7 +337,10 @@ fn test_no_match_schedule_overlap() {
         // this one does not match anymore
         let m = Match {
             job_id: job_id1.clone(),
-            sources: vec![processor_account_id()],
+            sources: vec![PlannedExecution {
+                source: processor_account_id(),
+                start_delay: 0,
+            }],
         };
         assert_err!(
             AcurastMarketplace::propose_matching(
@@ -422,7 +435,10 @@ fn test_more_reports_than_expected() {
 
         let m = Match {
             job_id: job_id.clone(),
-            sources: vec![processor_account_id()],
+            sources: vec![PlannedExecution {
+                source: processor_account_id(),
+                start_delay: 0,
+            }],
         };
         assert_ok!(AcurastMarketplace::propose_matching(
             RuntimeOrigin::signed(charlie_account_id()).into(),
@@ -478,6 +494,7 @@ fn test_more_reports_than_expected() {
                     processor_account_id(),
                     Assignment {
                         slot: 0,
+                        start_delay: 0,
                         fee_per_execution: MockAsset {
                             id: 0,
                             amount: 5_020_000
@@ -495,6 +512,7 @@ fn test_more_reports_than_expected() {
                     processor_account_id(),
                     Assignment {
                         slot: 0,
+                        start_delay: 0,
                         fee_per_execution: MockAsset {
                             id: 0,
                             amount: 5_020_000
@@ -512,6 +530,7 @@ fn test_more_reports_than_expected() {
                     processor_account_id(),
                     Assignment {
                         slot: 0,
+                        start_delay: 0,
                         fee_per_execution: MockAsset {
                             id: 0,
                             amount: 5_020_000

--- a/pallets/marketplace/src/tests.rs
+++ b/pallets/marketplace/src/tests.rs
@@ -120,7 +120,8 @@ fn test_match() {
 
         assert_ok!(AcurastMarketplace::report(
             RuntimeOrigin::signed(processor_account_id()).into(),
-            job_id.clone()
+            job_id.clone(),
+            false
         ));
         assert_eq!(
             Some(Assignment {
@@ -146,12 +147,13 @@ fn test_match() {
         );
 
         // pretend time moved on
-        later(registration.schedule.normalize(0).unwrap().0.end_time);
+        later(registration.schedule.normalize(0).unwrap().0.end_time - 2000);
         assert_eq!(3, System::block_number());
 
         assert_ok!(AcurastMarketplace::report(
             RuntimeOrigin::signed(processor_account_id()).into(),
-            job_id.clone()
+            job_id.clone(),
+            true,
         ));
         assert_eq!(
             None,
@@ -457,14 +459,16 @@ fn test_more_reports_than_expected() {
         later(iter.next().unwrap() + 1000);
         assert_ok!(AcurastMarketplace::report(
             RuntimeOrigin::signed(processor_account_id()).into(),
-            job_id.clone()
+            job_id.clone(),
+            false
         ));
 
         // pretend time moved on
         later(iter.next().unwrap() + 1000);
         assert_ok!(AcurastMarketplace::report(
             RuntimeOrigin::signed(processor_account_id()).into(),
-            job_id.clone()
+            job_id.clone(),
+            false
         ));
 
         // third report is illegal!
@@ -472,7 +476,8 @@ fn test_more_reports_than_expected() {
         assert_err!(
             AcurastMarketplace::report(
                 RuntimeOrigin::signed(processor_account_id()).into(),
-                job_id.clone()
+                job_id.clone(),
+                true
             ),
             Error::<Test>::MoreReportsThanExpected
         );

--- a/pallets/marketplace/src/tests.rs
+++ b/pallets/marketplace/src/tests.rs
@@ -147,7 +147,7 @@ fn test_match() {
         );
 
         // pretend time moved on
-        later(registration.schedule.normalize(0).unwrap().0.end_time - 2000);
+        later(registration.schedule.range(0).unwrap().1 - 2000);
         assert_eq!(3, System::block_number());
 
         assert_ok!(AcurastMarketplace::report(
@@ -472,7 +472,7 @@ fn test_more_reports_than_expected() {
         ));
 
         // third report is illegal!
-        later(registration.schedule.normalize(0).unwrap().0.end_time + 1000);
+        later(registration.schedule.range(0).unwrap().1 + 1000);
         assert_err!(
             AcurastMarketplace::report(
                 RuntimeOrigin::signed(processor_account_id()).into(),

--- a/pallets/marketplace/src/types.rs
+++ b/pallets/marketplace/src/types.rs
@@ -86,6 +86,8 @@ pub type PricingVariantFor<T> = PricingVariant<<T as Config>::AssetId, <T as Con
 pub struct Assignment<Reward> {
     /// The 0-based slot index assigned to the source.
     pub slot: u8,
+    /// The start delay for the first execution and all the following executions.
+    pub start_delay: u64,
     /// The fee owed to source for each execution.
     pub fee_per_execution: Reward,
     /// If this assignment was acknowledged.
@@ -138,12 +140,23 @@ where
     pub reward: Reward,
     /// Optional match provided with the job requirements. If provided, it gets processed instantaneously during
     /// registration call and validation errors lead to abortion of the call.
-    pub instant_match: Option<Vec<AccountId>>,
+    pub instant_match: Option<Vec<PlannedExecution<AccountId>>>,
 }
 
 /// A (one-sided) matching of a job to sources such that the requirements of both sides, consumer and source, are met.
 #[derive(RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Eq, PartialEq)]
 pub struct Match<AccountId> {
+    /// The job to match.
     pub job_id: JobId<AccountId>,
-    pub sources: Vec<AccountId>,
+    /// The sources to match each of the job's slots with.
+    pub sources: Vec<PlannedExecution<AccountId>>,
+}
+
+/// The details for a single planned slot execution with the delay.
+#[derive(RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Eq, PartialEq)]
+pub struct PlannedExecution<AccountId> {
+    /// The source.
+    pub source: AccountId,
+    /// The start delay for the first execution and all the following executions.
+    pub start_delay: u64,
 }

--- a/pallets/proxy/src/mock.rs
+++ b/pallets/proxy/src/mock.rs
@@ -46,6 +46,16 @@ impl Reward for AcurastAsset {
     }
 }
 
+#[cfg(feature = "runtime-benchmarks")]
+pub struct AcurastBenchmarkHelper;
+
+#[cfg(feature = "runtime-benchmarks")]
+impl pallet_assets::BenchmarkHelper<codec::Compact<AcurastAssetId>> for AcurastBenchmarkHelper {
+    fn create_asset_id_parameter(id: u32) -> codec::Compact<AcurastAssetId> {
+        codec::Compact(id)
+    }
+}
+
 pub mod acurast_runtime {
     use frame_support::{
         construct_runtime, parameter_types,
@@ -128,6 +138,7 @@ pub mod acurast_runtime {
         pub const MinimumPeriod: u64 = SLOT_DURATION / 2;
         pub const IsRelay: bool = false;
         pub const AcurastPalletId: PalletId = PalletId(*b"acrstpid");
+        pub const ReportTolerance: u64 = 12000;
     }
     parameter_types! {
         pub const BlockHashCount: u64 = 250;
@@ -233,6 +244,9 @@ pub mod acurast_runtime {
         type Extra = ();
         type WeightInfo = ();
         type RemoveItemsLimit = ();
+
+        #[cfg(feature = "runtime-benchmarks")]
+        type BenchmarkHelper = AcurastBenchmarkHelper;
     }
 
     pub struct FeeManagerImpl;
@@ -267,6 +281,7 @@ pub mod acurast_runtime {
         type RuntimeEvent = RuntimeEvent;
         type RegistrationExtra = JobRequirements<AcurastAsset, AccountId>;
         type PalletId = AcurastPalletId;
+        type ReportTolerance = ReportTolerance;
         type AssetId = AcurastAssetId;
         type AssetAmount = AcurastAssetAmount;
         type RewardManager = AssetRewardManager<AcurastAsset, AcurastBarrier, FeeManagerImpl>;


### PR DESCRIPTION
- `max_start_delay` is respected during validation on `propose_match` extrinsics
- `report`s are checked against the schedule
  - `Schedule` offers a helper to check for overlaps with unit tests
- `report` asks for collaboratively stating if it's the last execution (and datastructures can be cleaned up)