### PR TITLE
feat: add acurast hyperdrive pallet

### DIFF
--- a/pallets/hyperdrive/Cargo.toml
+++ b/pallets/hyperdrive/Cargo.toml
@@ -14,21 +14,26 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
-  "derive",
+	"derive",
 ] }
 
 # Benchmarks
+hex-literal = { version = "0.3", optional = true }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", optional = true, default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
 scale-info = { version = "2.2.0", default-features = false, features = [
-  "derive",
+	"derive",
 ] }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
 
 [dev-dependencies]
+hex-literal = "0.3"
+
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
@@ -38,12 +43,17 @@ log = "0.4.17"
 [features]
 default = ["std"]
 std = [
-  "codec/std",
-  "scale-info/std",
-  "frame-support/std",
-  "frame-system/std",
-  "frame-benchmarking/std",
+	"codec/std",
+	"scale-info/std",
+	"frame-support/std",
+	"frame-system/std",
+	"frame-benchmarking/std",
+	"sp-std/std",
+	"sp-runtime/std",
 ]
 
-runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
+runtime-benchmarks = [
+	"frame-benchmarking/runtime-benchmarks",
+	"hex-literal",
+]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallets/hyperdrive/Cargo.toml
+++ b/pallets/hyperdrive/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name = "pallet-acurast-hyperdrive"
+authors = ["Papers AG"]
+description = "Acurast Hyperdrive is a building block allowing for general bidirectional message passing"
+version = "0.0.1"
+license = "MIT"
+homepage = "https://docs.acurast.com/"
+edition = "2021"
+publish = false
+repository = "https://github.com/acurast/acurast-core"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+  "derive",
+] }
+
+# Benchmarks
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", optional = true, default-features = false }
+
+# Substrate
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
+scale-info = { version = "2.2.0", default-features = false, features = [
+  "derive",
+] }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
+
+[dev-dependencies]
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.36", default-features = false }
+log = "0.4.17"
+
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "scale-info/std",
+  "frame-support/std",
+  "frame-system/std",
+  "frame-benchmarking/std",
+]
+
+runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/hyperdrive/src/benchmarking.rs
+++ b/pallets/hyperdrive/src/benchmarking.rs
@@ -1,0 +1,11 @@
+//! Benchmarking setup
+
+use super::*;
+
+use frame_benchmarking::{benchmarks_instance_pallet, whitelisted_caller};
+use frame_system::RawOrigin;
+
+benchmarks_instance_pallet! {
+
+    impl_benchmark_test_suite!(crate::Pallet, crate::mock::new_test_ext(), crate::mock::Test);
+}

--- a/pallets/hyperdrive/src/lib.rs
+++ b/pallets/hyperdrive/src/lib.rs
@@ -118,17 +118,6 @@ pub mod pallet {
     >;
 
     #[pallet::storage]
-    #[pallet::getter(fn state_merkle_root_proposals)]
-    pub type StateMerkleRootProposals<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
-        _,
-        Blake2_128,
-        T::TargetChainBlockNumber,
-        Blake2_128,
-        T::AccountId,
-        T::TargetChainHash,
-    >;
-
-    #[pallet::storage]
     #[pallet::getter(fn state_merkle_root)]
     pub type StateMerkleRootCount<T: Config<I>, I: 'static = ()> = StorageDoubleMap<
         _,
@@ -225,11 +214,7 @@ pub mod pallet {
             );
 
             // insert merkle root proposal since all checks passed
-            // ---------------------------------------------------
-            // insert by whom submitted to track deviating submissions
-            // TODO blacklist transmitters with deviating submission?
-            StateMerkleRootProposals::<T, I>::insert(&block, &who, &state_merkle_root);
-            // update count for constant-time validity checks
+            // allows for constant-time validity checks
             let accepted =
                 StateMerkleRootCount::<T, I>::mutate(&block, &state_merkle_root, |count| {
                     let count_ = count.unwrap_or(0) + 1;

--- a/pallets/hyperdrive/src/lib.rs
+++ b/pallets/hyperdrive/src/lib.rs
@@ -1,0 +1,112 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+mod types;
+
+use frame_support::{dispatch::Weight, traits::Get};
+
+pub use pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+    use types::*;
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    #[pallet::without_storage_info]
+    pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+
+    #[pallet::config]
+    pub trait Config<I: 'static = ()>: frame_system::Config {
+        type RuntimeEvent: From<Event<Self, I>>
+            + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+        type StateRoot: Parameter + Member + MaxEncodedLen;
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config<I>, I: 'static = ()> {
+        StateSubmitted {
+            snapshot: u64,
+            root: T::StateRoot,
+        },
+        StateTransmittersUpdate {
+            added: Vec<(T::AccountId, types::ActivityWindow<T::BlockNumber>)>,
+            updated: Vec<(T::AccountId, types::ActivityWindow<T::BlockNumber>)>,
+            removed: Vec<T::AccountId>,
+        },
+    }
+
+    /// This storage field maps the state transmitters to their respective activiti window.
+    ///
+    /// These transmitters are responsible for submitting the merkle roots of supported
+    /// source chains to acurast.
+    #[pallet::storage]
+    #[pallet::getter(fn state_transmitter)]
+    pub type StateTransmitter<T: Config<I>, I: 'static = ()> =
+        StorageMap<_, Blake2_128, T::AccountId, ActivityWindow<T::BlockNumber>, ValueQuery>;
+
+    #[pallet::call]
+    impl<T: Config<I>, I: 'static> Pallet<T, I> {
+        /// This extrinsic is used to add, update or remove state transmitters.
+        #[pallet::call_index(0)]
+        #[pallet::weight(Weight::from_ref_time(10_000).saturating_add(T::DbWeight::get().reads_writes(1, 2)))]
+        pub fn update_state_transmitters(
+            origin: OriginFor<T>,
+            actions: Vec<StateTransmitterUpdate<T::AccountId, T::BlockNumber>>,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+
+            // Process actions
+            let (added, updated, removed) =
+                actions
+                    .iter()
+                    .fold((vec![], vec![], vec![]), |acc, action| {
+                        let (mut added, mut updated, mut removed) = acc;
+                        match action {
+                            StateTransmitterUpdate::Add(account, activity_window) => {
+                                <StateTransmitter<T, I>>::set(
+                                    account.clone(),
+                                    activity_window.clone(),
+                                );
+                                added.push((account.clone(), activity_window.clone()))
+                            }
+                            StateTransmitterUpdate::Update(account, activity_window) => {
+                                <StateTransmitter<T, I>>::set(
+                                    account.clone(),
+                                    activity_window.clone(),
+                                );
+                                updated.push((account.clone(), activity_window.clone()))
+                            }
+                            StateTransmitterUpdate::Remove(account) => {
+                                <StateTransmitter<T, I>>::remove(account);
+                                removed.push(account.clone())
+                            }
+                        }
+                        (added, updated, removed)
+                    });
+
+            // Emit event to inform that the state transmitters were updated
+            Self::deposit_event(Event::StateTransmittersUpdate {
+                added,
+                updated,
+                removed,
+            });
+
+            Ok(())
+        }
+    }
+}
+
+impl<T: Config<I>, I: 'static> Pallet<T, I> {}

--- a/pallets/hyperdrive/src/mock.rs
+++ b/pallets/hyperdrive/src/mock.rs
@@ -1,0 +1,82 @@
+use frame_support::{
+    traits::{ConstU16, ConstU64},
+    BoundedVec,
+};
+use frame_system as system;
+use sp_core::{ConstU32, H256};
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    AccountId32,
+};
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+    pub enum Test where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system,
+        TezosHyperdrive: crate,
+    }
+);
+
+impl system::Config for Test {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type DbWeight = ();
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type Index = u64;
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId32;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type RuntimeEvent = RuntimeEvent;
+    type BlockHashCount = ConstU64<250>;
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = ();
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ConstU16<42>;
+    type OnSetCode = ();
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+impl crate::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type StateRoot = BoundedVec<u8, ConstU32<32>>;
+}
+
+// Build genesis storage according to the mock runtime.
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let storage = system::GenesisConfig::default()
+        .build_storage::<Test>()
+        .unwrap()
+        .into();
+
+    let mut ext = sp_io::TestExternalities::new(storage);
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}
+
+pub fn events() -> Vec<RuntimeEvent> {
+    log::debug!("{:#?}", System::events());
+    let evt = System::events()
+        .into_iter()
+        .map(|evt| evt.event)
+        .collect::<Vec<_>>();
+
+    System::reset_events();
+
+    evt
+}

--- a/pallets/hyperdrive/src/mock.rs
+++ b/pallets/hyperdrive/src/mock.rs
@@ -1,9 +1,10 @@
 use frame_support::{
+    parameter_types,
     traits::{ConstU16, ConstU64},
-    BoundedVec,
 };
 use frame_system as system;
-use sp_core::{ConstU32, H256};
+use sp_core::H256;
+use sp_runtime::traits::Keccak256;
 use sp_runtime::{
     testing::Header,
     traits::{BlakeTwo256, IdentityLookup},
@@ -12,6 +13,11 @@ use sp_runtime::{
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
+
+parameter_types! {
+    pub const TransmissionRate: u64 = 5;
+    pub const TransmissionQuorum: u8 = 2;
+}
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
@@ -54,7 +60,11 @@ impl system::Config for Test {
 
 impl crate::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type StateRoot = BoundedVec<u8, ConstU32<32>>;
+    type TargetChainHash = H256;
+    type TargetChainBlockNumber = u64;
+    type TargetChainHashing = Keccak256;
+    type TransmissionRate = TransmissionRate;
+    type TransmissionQuorum = TransmissionQuorum;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/hyperdrive/src/tests.rs
+++ b/pallets/hyperdrive/src/tests.rs
@@ -1,0 +1,108 @@
+#![cfg(test)]
+
+use frame_support::{assert_ok, assert_err, error::BadOrigin};
+use sp_runtime::AccountId32;
+
+use crate::{
+    mock::*,
+    types::{ActivityWindow, StateTransmitterUpdate},
+};
+
+pub fn alice_account_id() -> AccountId32 {
+    [0; 32].into()
+}
+
+#[test]
+fn update_state_transmitters() {
+    let mut test = new_test_ext();
+
+    test.execute_with(|| {
+
+        // A single action
+
+        let actions = vec![StateTransmitterUpdate::Add(
+            alice_account_id(),
+            ActivityWindow {
+                start_block: 0,
+                end_block: 100,
+            },
+        )];
+
+        assert_ok!(TezosHyperdrive::update_state_transmitters(
+            RuntimeOrigin::root().into(),
+            actions
+        ));
+
+        assert_eq!(
+            events(),
+            [RuntimeEvent::TezosHyperdrive(
+                crate::Event::StateTransmittersUpdate {
+                    added: vec![(
+                        alice_account_id(),
+                        ActivityWindow {
+                            start_block: 0,
+                            end_block: 100
+                        }
+                    )],
+                    updated: vec![],
+                    removed: vec![],
+                }
+            )]
+        );
+
+        // Multiple actions
+
+        let actions = vec![
+            StateTransmitterUpdate::Add(
+                alice_account_id(),
+                ActivityWindow {
+                    start_block: 0,
+                    end_block: 100,
+                },
+            ),
+            StateTransmitterUpdate::Update(
+                alice_account_id(),
+                ActivityWindow {
+                    start_block: 0,
+                    end_block: 100,
+                },
+            ),
+            StateTransmitterUpdate::Remove(alice_account_id()),
+        ];
+
+        assert_ok!(TezosHyperdrive::update_state_transmitters(
+            RuntimeOrigin::root().into(),
+            actions.clone()
+        ));
+
+        assert_eq!(
+            events(),
+            [RuntimeEvent::TezosHyperdrive(
+                crate::Event::StateTransmittersUpdate {
+                    added: vec![(
+                        alice_account_id(),
+                        ActivityWindow {
+                            start_block: 0,
+                            end_block: 100
+                        }
+                    )],
+                    updated: vec![(
+                        alice_account_id(),
+                        ActivityWindow {
+                            start_block: 0,
+                            end_block: 100
+                        }
+                    )],
+                    removed: vec![(alice_account_id())],
+                }
+            )]
+        );
+
+        // Non root calls should fail
+
+        assert_err!(TezosHyperdrive::update_state_transmitters(
+            RuntimeOrigin::signed(alice_account_id()).into(),
+            actions
+        ), BadOrigin);
+    });
+}

--- a/pallets/hyperdrive/src/tests.rs
+++ b/pallets/hyperdrive/src/tests.rs
@@ -1,23 +1,31 @@
 #![cfg(test)]
 
-use frame_support::{assert_ok, assert_err, error::BadOrigin};
+use frame_support::{assert_err, assert_ok, error::BadOrigin};
+use hex_literal::hex;
+use sp_core::H256;
 use sp_runtime::AccountId32;
 
 use crate::{
     mock::*,
     types::{ActivityWindow, StateTransmitterUpdate},
+    Error,
 };
 
 pub fn alice_account_id() -> AccountId32 {
     [0; 32].into()
 }
+pub fn bob_account_id() -> AccountId32 {
+    [1; 32].into()
+}
+pub const HASH: H256 = H256(hex!(
+    "a3f18e4c6f0cdd0d8666f407610351cacb9a263678cf058294be9977b69f2cb3"
+));
 
 #[test]
-fn update_state_transmitters() {
+fn update_single_state_transmitters() {
     let mut test = new_test_ext();
 
     test.execute_with(|| {
-
         // A single action
 
         let actions = vec![StateTransmitterUpdate::Add(
@@ -49,9 +57,14 @@ fn update_state_transmitters() {
                 }
             )]
         );
+    });
+}
 
-        // Multiple actions
+#[test]
+fn update_multiple_state_transmitters() {
+    let mut test = new_test_ext();
 
+    test.execute_with(|| {
         let actions = vec![
             StateTransmitterUpdate::Add(
                 alice_account_id(),
@@ -97,12 +110,211 @@ fn update_state_transmitters() {
                 }
             )]
         );
+    });
+}
 
-        // Non root calls should fail
+/// Non root calls should fail
+#[test]
+fn update_state_transmitters_non_root() {
+    let mut test = new_test_ext();
 
-        assert_err!(TezosHyperdrive::update_state_transmitters(
-            RuntimeOrigin::signed(alice_account_id()).into(),
+    test.execute_with(|| {
+        let actions = vec![StateTransmitterUpdate::Add(
+            alice_account_id(),
+            ActivityWindow {
+                start_block: 0,
+                end_block: 100,
+            },
+        )];
+
+        assert_err!(
+            TezosHyperdrive::update_state_transmitters(
+                RuntimeOrigin::signed(alice_account_id()).into(),
+                actions
+            ),
+            BadOrigin
+        );
+    });
+}
+
+#[test]
+fn submit_outside_activity_window() {
+    let mut test = new_test_ext();
+
+    test.execute_with(|| {
+        let actions = vec![StateTransmitterUpdate::Add(
+            alice_account_id(),
+            ActivityWindow {
+                start_block: 10,
+                end_block: 20,
+            },
+        )];
+
+        assert_ok!(TezosHyperdrive::update_state_transmitters(
+            RuntimeOrigin::root().into(),
             actions
-        ), BadOrigin);
+        ));
+
+        System::set_block_number(9);
+        assert_err!(
+            TezosHyperdrive::submit_state_merkle_root(
+                RuntimeOrigin::signed(alice_account_id()),
+                5,
+                HASH
+            ),
+            Error::<Test, ()>::SubmitOutsideTransmitterActivityWindow
+        );
+
+        System::set_block_number(10);
+        assert_ok!(TezosHyperdrive::submit_state_merkle_root(
+            RuntimeOrigin::signed(alice_account_id()),
+            10,
+            HASH
+        ));
+
+        System::set_block_number(19);
+        assert_ok!(TezosHyperdrive::submit_state_merkle_root(
+            RuntimeOrigin::signed(alice_account_id()),
+            10,
+            HASH
+        ));
+
+        System::set_block_number(20);
+        assert_err!(
+            TezosHyperdrive::submit_state_merkle_root(
+                RuntimeOrigin::signed(bob_account_id()),
+                5,
+                HASH
+            ),
+            Error::<Test, ()>::SubmitOutsideTransmitterActivityWindow
+        );
+    });
+}
+
+#[test]
+fn submit_outside_transmission_rate() {
+    let mut test = new_test_ext();
+
+    test.execute_with(|| {
+        let actions = vec![StateTransmitterUpdate::Add(
+            alice_account_id(),
+            ActivityWindow {
+                start_block: 10,
+                end_block: 20,
+            },
+        )];
+
+        assert_ok!(TezosHyperdrive::update_state_transmitters(
+            RuntimeOrigin::root().into(),
+            actions
+        ));
+
+        System::set_block_number(10);
+        assert_err!(
+            TezosHyperdrive::submit_state_merkle_root(
+                RuntimeOrigin::signed(bob_account_id()),
+                6,
+                HASH
+            ),
+            Error::<Test, ()>::SubmitOutsideTransmitterActivityWindow
+        );
+    });
+}
+
+#[test]
+fn submit_state_merkle_root() {
+    let mut test = new_test_ext();
+
+    test.execute_with(|| {
+        let actions = vec![
+            StateTransmitterUpdate::Add(
+                alice_account_id(),
+                ActivityWindow {
+                    start_block: 10,
+                    end_block: 20,
+                },
+            ),
+            StateTransmitterUpdate::Add(
+                bob_account_id(),
+                ActivityWindow {
+                    start_block: 10,
+                    end_block: 50,
+                },
+            ),
+        ];
+
+        assert_ok!(TezosHyperdrive::update_state_transmitters(
+            RuntimeOrigin::root().into(),
+            actions
+        ));
+
+        System::set_block_number(10);
+
+        // first submission for target chain block 10
+        assert_ok!(TezosHyperdrive::submit_state_merkle_root(
+            RuntimeOrigin::signed(alice_account_id()),
+            10,
+            HASH
+        ));
+        // does not validate until quorum reached
+        assert_eq!(TezosHyperdrive::validate_state_merkle_root(10, HASH), false);
+
+        // intermitted submission for different block is allowed!
+        assert_ok!(TezosHyperdrive::submit_state_merkle_root(
+            RuntimeOrigin::signed(bob_account_id()),
+            15,
+            HASH
+        ));
+
+        // second submission for target chain block 10
+        assert_ok!(TezosHyperdrive::submit_state_merkle_root(
+            RuntimeOrigin::signed(bob_account_id()),
+            10,
+            HASH
+        ));
+        // does validate since quorum reached
+        assert_eq!(TezosHyperdrive::validate_state_merkle_root(10, HASH), true);
+
+        assert_eq!(
+            events(),
+            [
+                RuntimeEvent::TezosHyperdrive(crate::Event::StateTransmittersUpdate {
+                    added: vec![
+                        (
+                            alice_account_id(),
+                            ActivityWindow {
+                                start_block: 10,
+                                end_block: 20
+                            }
+                        ),
+                        (
+                            bob_account_id(),
+                            ActivityWindow {
+                                start_block: 10,
+                                end_block: 50
+                            }
+                        )
+                    ],
+                    updated: vec![],
+                    removed: vec![],
+                }),
+                RuntimeEvent::TezosHyperdrive(crate::Event::StateMerkleRootSubmitted {
+                    block: 10,
+                    state_merkle_root: HASH
+                }),
+                RuntimeEvent::TezosHyperdrive(crate::Event::StateMerkleRootSubmitted {
+                    block: 15,
+                    state_merkle_root: HASH
+                }),
+                RuntimeEvent::TezosHyperdrive(crate::Event::StateMerkleRootSubmitted {
+                    block: 10,
+                    state_merkle_root: HASH
+                }),
+                RuntimeEvent::TezosHyperdrive(crate::Event::StateMerkleRootAccepted {
+                    block: 10,
+                    state_merkle_root: HASH
+                })
+            ]
+        );
     });
 }

--- a/pallets/hyperdrive/src/types.rs
+++ b/pallets/hyperdrive/src/types.rs
@@ -1,0 +1,27 @@
+use codec::{Decode, Encode};
+use frame_support::RuntimeDebug;
+use scale_info::TypeInfo;
+
+/// This struct defines the transmitter activity window
+#[derive(RuntimeDebug, Encode, Decode, TypeInfo, Clone, PartialEq)]
+pub struct ActivityWindow<BlockNumber> {
+    /// From this block on, the transmitter is permitted to submit Merkle roots.
+    pub start_block: BlockNumber,
+    /// From this block on, the transmitter is not permitted to submit any Merkle root.
+    pub end_block: BlockNumber,
+}
+impl<BlockNumber: From<u8>> Default for ActivityWindow<BlockNumber> {
+    fn default() -> Self {
+        Self {
+            start_block: BlockNumber::from(0),
+            end_block: BlockNumber::from(0),
+        }
+    }
+}
+
+#[derive(RuntimeDebug, Encode, Decode, TypeInfo, Clone, PartialEq)]
+pub enum StateTransmitterUpdate<AccountId, BlockNumber> {
+    Add(AccountId, ActivityWindow<BlockNumber>),
+    Remove(AccountId),
+    Update(AccountId, ActivityWindow<BlockNumber>),
+}


### PR DESCRIPTION
## Summary

create a `pallet_acurast_hyperdrive` to support external chain state sync and add support for the Tezos chain proof validation.

## What is the expected behavior?
<!--- What the user should see / can do --->

- submit merkle root extrisic (snapshot number (uint), merkle root (bytes))
- submit proof extrinsic (key/value, proof path, snapshot number, nonce)
  - requires a nonce